### PR TITLE
Testing updates

### DIFF
--- a/allactive/testlist_allactive.xml
+++ b/allactive/testlist_allactive.xml
@@ -49,14 +49,6 @@
       <option name="wallclock"> 04:00 </option>
     </options>
   </test>
-  <test name="SMS_D" grid="f09_g16" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="yellowstone" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 02:00 </option>
-    </options>
-  </test>
   <test name="ERS" grid="f19_g16" compset="B1850C4L45BGCRBPRPWs" testmods="allactive/defaultio">
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>

--- a/allactive/testmods_dirs/allactive/defaultio/user_nl_clm
+++ b/allactive/testmods_dirs/allactive/defaultio/user_nl_clm
@@ -2,3 +2,4 @@
  hist_ndens     = 1
  hist_nhtfrq    =-24
  hist_mfilt     = 1
+ for_testing_allow_non_annual_changes = .true.


### PR DESCRIPTION
Remove SMS_D.f09_g16.B1850 tests from yellowstone, use ERS_D.f09_g16.B1850 instead.
Add for_testing_allow_non_annual_changes = .true. to allow testing of some clm compsets.