### PR TITLE
Use GLC_AVG_PERIOD=glc_coupling_period for test_coupling testmod

### DIFF
--- a/testmods_dirs/allactive/defaultio/shell_commands
+++ b/testmods_dirs/allactive/defaultio/shell_commands
@@ -1,0 +1,2 @@
+# Since we're doing a daily mass balance time step in CISM, we can't use the default GLC_AVG_PERIOD of yearly
+./xmlchange GLC_AVG_PERIOD=glc_coupling_period


### PR DESCRIPTION
With some cime changes that will come in soon, together with the new
cism tag cism2_1_30, we will typically just be sending valid fields from
CLM to CISM on the year boundary. But that doesn't work well with the
test_coupling cism testmod, which forces CISM to run its dynamics every
day rather than every year (so that the dynamics can be exercised in
short tests).

So this PR makes it so that, in tests where we use this CISM test mod,
we also revert to the old behavior of having the coupler send valid
surface mass balance forcings every day.

This change is dependent on a cime change (PR coming soon) and the
changes in cism2_1_30 - so all of these changes should be coordinated.
