### PR TITLE
Update some testing wallclock limits for cheyenne

### DIFF
--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -46,7 +46,7 @@
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 02:00 </option>
     </options>
   </test>
   <test name="ERS_D" grid="f09_g16" compset="B1850" testmods="allactive/defaultio">
@@ -138,7 +138,7 @@
       <machine name="yellowstone" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 01:00 </option>
     </options>
   </test>
   <test name="ERS_Ld5" grid="f19_g16" compset="E1850C5L45TEST" testmods="cice/default">
@@ -198,7 +198,7 @@
       <machine name="yellowstone" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 01:00 </option>
+      <option name="wallclock"> 02:00 </option>
     </options>
   </test>
   <!-- <test name="ERS_N3_Ld7" grid="f19_g16" compset="BHISTC5L40CNR" testmods="allactive/defaultio"> -->


### PR DESCRIPTION
Some of the B compset tests for cheyenne were exceeding the set WALLCLOCK.