### PR TITLE
Zero out CLM's dynbal adjustments in the allactive-defaultio testmod

### DIFF
--- a/testmods_dirs/allactive/defaultio/user_nl_clm
+++ b/testmods_dirs/allactive/defaultio/user_nl_clm
@@ -3,3 +3,11 @@
  hist_nhtfrq    =-24
  hist_mfilt     = 1
  for_testing_allow_non_annual_changes = .true.
+
+ ! When we have daily rather than annual glacier dynamics (as we do in this testmod, due
+ ! to having test_coupling in user_nl_cism), CLM applies the dynbal adjustments in a
+ ! single time step rather than spreading them throughout the year. This can cause
+ ! sensible heat fluxes of thousands of W m-2, which causes CAM's PBL scheme to blow up.
+ ! So force these fluxes to zero for this testmod; this breaks water and energy
+ ! conservation in CLM, but should allow the test to pass.
+ for_testing_zero_dynbal_fluxes = .true.


### PR DESCRIPTION
When we have daily rather than annual glacier dynamics (as we do in this
testmod, due to having test_coupling in user_nl_cism), CLM applies the
dynbal adjustments in a single time step rather than spreading them
throughout the year. This can cause sensible heat fluxes of thousands of
W m-2, which causes CAM's PBL scheme to blow up.  So force these fluxes
to zero for this testmod; this breaks water and energy conservation in
CLM, but should allow the test to pass.

This depends on clm4_5_15_r235