### PR TITLE
Add explicit "%EVOLVE" for compsets with CISM

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -231,7 +231,7 @@
 
   <compset>
     <alias>BC5L45BGCRG</alias>
-    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2_SWAV</lname>
+    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <compset>
@@ -241,7 +241,7 @@
 
   <compset>
     <alias>B1850C5L45BGCRG</alias>
-    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2_SWAV</lname>
+    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
@@ -249,7 +249,7 @@
        check the PE layout. -->
   <compset>
     <alias>B1850C5L45BGCRG1</alias>
-    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM1_SWAV</lname>
+    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM1%EVOLVE_SWAV</lname>
   </compset>
 
   <!-- Prognostic wave -->
@@ -278,7 +278,7 @@
 
   <compset>
      <alias>J1850G</alias>
-     <lname>1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2_SWAV</lname>
+     <lname>1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <entries>


### PR DESCRIPTION
As of cism2_1_35, CISM expects an explicit "%EVOLVE" or "%NOEVOLVE".

I'll be honest: I haven't tested this, though I have triple-checked it for correctness (e.g., typos).

I think it's safe to bring this in before cism2_1_35 (which is currently on the plans page for cesm2_0_alpha06p). The only reason it would cause a problem to bring this in earlier is if the error-checking of compset options has been implemented (so would say that "%EVOLVE" is not a defined compset option). But I don't think that has been implemented to throw an error yet.