### PR TITLE
Updating testlist for hobart

### DIFF
--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -194,7 +194,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="PEA_P1" grid="f45_g37" compset="B1850" testmods="allactive/defaultio">
+  <test name="PEA_P1" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="hobart" compiler="intel" category="prebeta"/>
       <machine name="hobart" compiler="pgi" category="prebeta"/>
@@ -338,14 +338,6 @@
     </machines>
     <options>
       <option name="wallclock">  00:20 </option>
-    </options>
-  </test>
-  <test name="PRE" grid="f19_f19_mg16" compset="ADESP_TEST">
-    <machines>
-      <machine name="hobart" compiler="nag" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:20 </option>
     </options>
   </test>
 </testlist>

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -72,7 +72,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:25 </option>
     </options>
   </test>
   <test name="ERS" grid="f09_g17" compset="BRCP85C5L45BGCR" testmods="allactive/defaultio">


### PR DESCRIPTION
Changed PEA_P1.f45_g37.B1850 hobart test to PEA_P1.f19_g17.B1850 hobart test.
Moved PRE.f19_f19_mg16.ADESP_TEST.hobart_nag from cime_config to CIME's mct driver.
Also tweaked wallclock for ERS.f19_g17.B1850Ws test.

Fixes #15 #17