### PR TITLE
Tweak BG compsets

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -205,6 +205,11 @@
     <lname>RCP8_CAM50_CLM45%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
   </compset>
 
+  <compset>
+    <alias>BC5L45BGCR</alias>
+    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
+  </compset>
+
   <!-- Climate Simulation Lab compsets for Keith Lindsay -->
 
   <compset>
@@ -227,29 +232,19 @@
 <!--    <lname>HIST_CAM40_CLM40%CN_CICE_POP2%ECO_RTM_SGLC_SWAV_BGC%BDRD</lname> -->
 <!--  </compset> -->
 
-  <!-- BG compsets -->
+  <!-- BG compsets: evolving ice sheet -->
 
   <compset>
-    <alias>BC5L45BGCRG</alias>
-    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2%EVOLVE_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>BC5L45BGCR</alias>
-    <lname>2000_CAM50_CLM45%BGC_CICE_POP2_RTM_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
-    <alias>B1850C5L45BGCRG</alias>
-    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM2%EVOLVE_SWAV</lname>
+    <alias>B1850G</alias>
+    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
        CISM1 can operate in a fully-coupled configuration. Main point is to
        check the PE layout. -->
   <compset>
-    <alias>B1850C5L45BGCRG1</alias>
-    <lname>1850_CAM50_CLM45%BGC_CICE_POP2_RTM_CISM1%EVOLVE_SWAV</lname>
+    <alias>B1850G1</alias>
+    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- Prognostic wave -->

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -185,7 +185,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="BC5L45BGCRG" testmods="allactive/defaultio">
+  <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
@@ -289,7 +289,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
@@ -298,7 +298,7 @@
       <option name="wallclock"> 00:20 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850C5L45BGCRG1" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G1" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prebeta">
         <options>
@@ -308,7 +308,7 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="BC5L45BGCRG" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="hobart" compiler="nag" category="prebeta"/>
     </machines>


### PR DESCRIPTION
These are compsets that have an evolving ice sheet

I removed the year-2000 compset, and made the year-1850 compsets match
the standard B1850 configuration.

Also, I moved a compset that was incorrectly placed in this "BG" section