### PR TITLE
Adding CROP to B compsets

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+?xml version="1.0"?>
 
 <compsets version="2.0">
 
@@ -277,30 +277,19 @@
   </compset>
 
   <entries>
-
-  <entry id="RUN_TYPE">
-    <values>
-      <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
-    </values>
-    </entry>
-    <entry id="RUN_REFCASE">
+    <entry id="RUN_TYPE">
       <values>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD">b.e15.B1850G.f09_g16.pi_control.25</value>
-      </values>
-    </entry>
-    <entry id="RUN_REFDATE">
-      <values>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"			   >0041-01-01</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD"   >hybrid</value>
       </values>
     </entry>
     <entry id="RUN_STARTDATE">
       <values>
-	<value compset="1850_"     >0001-01-01</value>
-	<value compset="2000_"     >0001-01-01</value>
-	<value compset="HIST_"     >1850-01-01</value>
-	<value compset="5505_"     >1955-01-01</value>
-	<value compset="RCP[2468]_">2005-01-01</value>
-	<value compset="2013_"     >2013-01-01</value>
+        <value compset="1850_"     >0001-01-01</value>
+        <value compset="2000_"     >0001-01-01</value>
+        <value compset="HIST_"     >1850-01-01</value>
+        <value compset="5505_"     >1955-01-01</value>
+        <value compset="RCP[2468]_">2005-01-01</value>
+        <value compset="2013_"     >2013-01-01</value>
       </values>
     </entry>
   </entries>

--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -41,18 +41,18 @@
 
   <compset>
     <alias>B1850Ws</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>B1850</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
     <science_support grid="f09_g16"/>
   </compset>
 
   <compset>
     <alias>BW1850</alias>
-    <lname>1850_CAM60%WCTS_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
+    <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
     <science_support grid="f09_g16"/>
   </compset>
 
@@ -100,12 +100,12 @@
 
   <compset>
     <alias>BHIST</alias>
-    <lname>HIST_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
+    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <compset>
     <alias>BHISTWs</alias>
-    <lname>HIST_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
+    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD</lname>
   </compset>
 
   <!-- <compset> -->
@@ -236,7 +236,7 @@
 
   <compset>
     <alias>B1850G</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
@@ -244,7 +244,7 @@
        check the PE layout. -->
   <compset>
     <alias>B1850G1</alias>
-    <lname>1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%EVOLVE_WW3_BGC%BDRD</lname>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
   <!-- Prognostic wave -->
@@ -273,24 +273,24 @@
 
   <compset>
      <alias>J1850G</alias>
-     <lname>1850_DATM%CRU_CLM50%BGC_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
+     <lname>1850_DATM%CRU_CLM50%BGC-CROP_CICE_POP2_MOSART_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <entries>
 
   <entry id="RUN_TYPE">
     <values>
-      <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
+      <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"	compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"	   >hybrid</value>
     </values>
     </entry>
     <entry id="RUN_REFCASE">
       <values>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD">b.e15.B1850G.f09_g16.pi_control.25</value>
+	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD">b.e15.B1850G.f09_g16.pi_control.25</value>
       </values>
     </entry>
     <entry id="RUN_REFDATE">
       <values>
-	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"			   >0041-01-01</value>
+	<value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v6_r%r05_m%gx1v6_g%gland5UM_w%null"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM1%NOEVOLVE_SWAV_BGC%BDRD"			   >0041-01-01</value>
       </values>
     </entry>
     <entry id="RUN_STARTDATE">

--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -1,4 +1,4 @@
-?xml version="1.0"?>
+<?xml version="1.0"?>
 
 <compsets version="2.0">
 

--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -277,11 +277,6 @@
   </compset>
 
   <entries>
-    <entry id="RUN_TYPE">
-      <values>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"   compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD"   >hybrid</value>
-      </values>
-    </entry>
     <entry id="RUN_STARTDATE">
       <values>
         <value compset="1850_"     >0001-01-01</value>

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -29,7 +29,7 @@
       <machine name="edison" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="NCK" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultio">
@@ -53,7 +53,7 @@
     <machines>
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
       <options>
-	<option name="wallclock"> 00:20 </option>
+	<option name="wallclock"> 00:30 </option>
       </options>
     </machines>
   </test>
@@ -80,7 +80,7 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld7" grid="ne30_g17" compset="B1850" testmods="allactive/defaultio">
@@ -88,7 +88,7 @@
       <machine name="cheyenne" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
@@ -97,7 +97,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="SMS_Ld5" grid="f09_g17" compset="BW1850" testmods="allactive/default">
@@ -122,7 +122,7 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld7" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
@@ -131,7 +131,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld7" grid="ne30_g17" compset="B1850" testmods="allactive/defaultio">
@@ -140,7 +140,7 @@
       <machine name="cheyenne" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld7" grid="f09_g17" compset="BHISTC5L45BGCR" testmods="allactive/defaultio">
@@ -148,7 +148,7 @@
       <machine name="bluewaters" compiler="pgi" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_Ld9" grid="ne120_g17" compset="B1850" testmods="allactive/defaultio">
@@ -156,7 +156,7 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="ERS_N3_Ld7" grid="f19_g17" compset="BHISTWs" testmods="allactive/defaultio">
@@ -174,7 +174,7 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="NCK_Ld5" grid="f19_g17" compset="BC5L45BGCR" testmods="allactive/defaultio">
@@ -182,7 +182,7 @@
       <machine name="cheyenne" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
@@ -191,7 +191,7 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="PEA_P1" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
@@ -200,7 +200,7 @@
       <machine name="hobart" compiler="pgi" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="PET" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
@@ -208,7 +208,7 @@
       <machine name="cheyenne" compiler="gnu" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="PET" grid="ne30_g17" compset="B1850" testmods="allactive/defaultio">
@@ -216,7 +216,7 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <!-- <test name="PET" grid="f19_g17" compset="B1850C5L40SPRWs" testmods="allactive/defaultio"> -->
@@ -224,7 +224,7 @@
   <!--     <machine name="bluewaters" compiler="pgi" category="prebeta"/> -->
   <!--   </machines> -->
   <!--   <options> -->
-  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--     <option name="wallclock"> 00:30 </option> -->
   <!--   </options> -->
   <!-- </test> -->
   <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/default">
@@ -269,7 +269,7 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
 
@@ -278,7 +278,7 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="SMS_D" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
@@ -286,7 +286,7 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G" testmods="allactive/defaultio">
@@ -295,14 +295,14 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G1" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prebeta">
         <options>
-          <option name="wallclock">0:20</option>
+          <option name="wallclock">0:30</option>
           <option name="comment">Include a fully-coupled test with CISM1, mainly to make sure the PE layout works</option>
         </options>
       </machine>
@@ -313,7 +313,7 @@
       <machine name="hobart" compiler="nag" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <!-- <test name="SMS_Ld5" grid="f09_g17" compset="BRCP85C4L40CNRBPRP" testmods="allactive/defaultio"> -->
@@ -321,7 +321,7 @@
   <!--     <machine name="edison" compiler="intel" category="prebeta"/> -->
   <!--   </machines> -->
   <!--   <options> -->
-  <!--     <option name="wallclock"> 00:20 </option> -->
+  <!--     <option name="wallclock"> 00:30 </option> -->
   <!--   </options> -->
   <!-- </test> -->
   <test name="SMS_Ld5" grid="f09_g17_gl4" compset="J1850G" testmods="allactive/defaultio">
@@ -329,7 +329,7 @@
       <machine name="cheyenne" compiler="gnu" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:20 </option>
+      <option name="wallclock"> 00:30 </option>
     </options>
   </test>
   <test name="SMS_Ld7" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
@@ -337,7 +337,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock">  00:20 </option>
+      <option name="wallclock">  00:30 </option>
     </options>
   </test>
 </testlist>


### PR DESCRIPTION
Add -CROP to B compsets that have CLM50%BGC.
    Answer changes for affected B compsets.
Also tweaked wallclocks in the test lists.

Fixes #20 