### PR TITLE
Fix B1850G tests

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -239,6 +239,12 @@
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_WW3_BGC%BDRD</lname>
   </compset>
 
+  <!-- This is just needed for testing multi-instance, because WW3 currently does not support multi-instance -->
+  <compset>
+    <alias>B1850GWs</alias>
+    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%EVOLVE_SWAV_BGC%BDRD</lname>
+  </compset>
+
   <!-- Include one CISM1 compset, mainly for testing purposes, to make sure that
        CISM1 can operate in a fully-coupled configuration. Main point is to
        check the PE layout. -->

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -191,7 +191,7 @@
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 01:30 </option>
       <option name="comment">Needs to be B1850GWs rather than B1850G because WW3 currently does not support multi-instance</option>
     </options>
   </test>

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -185,13 +185,14 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
+  <test name="NCK_Ld5" grid="f19_g17" compset="B1850GWs" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
+      <option name="comment">Needs to be B1850GWs rather than B1850G because WW3 currently does not support multi-instance</option>
     </options>
   </test>
   <test name="PEA_P1" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -290,16 +290,23 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 00:30 </option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f09_g17" compset="B1850G" testmods="allactive/defaultio">
+    <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G1" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G1" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prebeta">
         <options>
@@ -309,7 +316,7 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ld5" grid="T31_g37_gl20" compset="B1850G" testmods="allactive/defaultio">
+  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="hobart" compiler="nag" category="prebeta"/>
     </machines>

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -316,12 +316,12 @@
       </machine>
     </machines>
   </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
+  <test name="SMS_Ld1" grid="f19_g17" compset="B1850G" testmods="allactive/defaultio">
     <machines>
       <machine name="hobart" compiler="nag" category="prebeta"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 00:45 </option>
     </options>
   </test>
   <!-- <test name="SMS_Ld5" grid="f09_g17" compset="BRCP85C4L40CNRBPRP" testmods="allactive/defaultio"> -->


### PR DESCRIPTION
Two changes here:

(1) Switch NCK B1850G test to use SWAV

This is needed because WW3 currently doesn't support multi-instance

(2) Change B1850G T31_g37_gl20 tests to f19 or f09

Main reason is that CAM6 apparently does not support T31. Other points
are: (1) change these to use the production CISM resolution (partly so
we're testing the production resolution, partly because we don't have
grid aliases defined with gl20 for f19); (2) include at least one test
of B1850G at the production resolution f09_g17.


Some tests still fail, but I'm not sure what to do about this. Specifically:

These pass:

NCK_Ld5.f19_g17.B1850GWs.cheyenne_intel.allactive-defaultio
SMS_Ld5.f09_g17.B1850G.cheyenne_intel.allactive-defaultio
SMS_Ld5.f19_g17.B1850G.cheyenne_intel.allactive-defaultio

This fails in the CLM build due to a build problem that makes no sense to me (and at the very least seems unrelated to this specific test); has this shown up in other tests?

SMS_Ld5.f19_g17.B1850G1.cheyenne_gnu.allactive-defaultio

```
/glade2/scratch2/sacks/cesm_code/cesm2_0_alpha06_newCimeConfig/components/clm/src/biogeophys/IrrigationMod.F90:1043:8:

     use pftconMod, only : pftcon
        1
Error: Common block member ‘mpi_status_ignore’ at (1) cannot be an EQUIVALENCE object in the pure procedure ‘pointneedscheckforirrig’
```

(I guess a workaround would be to remove the `pure` designation on pointNeedsCheckForIrrig, but this error really makes no sense to me and smells more like a compiler bug than anything else.)


Finally, this fails due to running out of wallclock time:

SMS_Ld5.f19_g17.B1850G.hobart_nag.allactive-defaultio

I'm retrying with a shorter test (1 day) and longer allowed wallclock time. I'll update the PR in the morning if that passes.