### PR TITLE
Fixes and updates for testing

### DIFF
--- a/config_pes.xml
+++ b/config_pes.xml
@@ -111,6 +111,38 @@
           <rootpe_cpl>0</rootpe_cpl>
         </rootpe>
       </pes>
+      <pes pesize="M" compset="CAM.+CLM.+CICE.+POP.+WW3.+">
+        <ntasks>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_cpl>-4</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>-2</rootpe_ice>
+          <rootpe_ocn>-4</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
     </mach>
   </grid>
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1">

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -127,8 +127,9 @@
   </test>
   <test name="ERS_Ld7" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="bluewaters" compiler="pgi"   category="prebeta"/>
+      <machine name="cheyenne"   compiler="intel" category="prealpha"/>
+      <machine name="hobart"     compiler="pgi"   category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>
@@ -204,9 +205,10 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="PET" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prealpha"/>
+      <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 00:30 </option>


### PR DESCRIPTION
Change PET tests on cheyenne to PET_PM to use pe-layout that works with the test, and add an intel test.
Add a 2deg B1850 PGI test to hobart.
Add pesize="M" pe-layout for the PET_PM test on cheyenne.