### PR TITLE
Change IRT_Ld5 test to IRT_Ld7

### DIFF
--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -109,7 +109,7 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="IRT_Ld5" grid="T31_g37" compset="B1850C5L45BGCR" testmods="allactive/defaultio">
+  <test name="IRT_Ld7" grid="T31_g37" compset="B1850C5L45BGCR" testmods="allactive/defaultio">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>


### PR DESCRIPTION
IRT_Ld5 was too short for a B1850 restart, IRT_Ld7 is long enough.