### PR TITLE
Addd allactive 1850 WACCM middle atmosphere chemistry compset

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -55,6 +55,10 @@
     <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
     <science_support grid="f09_g16"/>
   </compset>
+  <compset>
+    <alias>BWma1850</alias>
+    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3</lname>
+  </compset>
 
   <!--
        Other B water isotope compsets that are only relevant for clm water isotope branches

--- a/config_pes.xml
+++ b/config_pes.xml
@@ -1216,7 +1216,7 @@
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >
     <mach name="cheyenne">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+WW3.+">
+      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+WW3">
 	<comment>about 5ypd expected</comment>
 	<ntasks>
 	  <ntasks_atm>-16</ntasks_atm>
@@ -1282,40 +1282,6 @@
 	  <rootpe_cpl>0</rootpe_cpl>
 	</rootpe>
       </pes>
-      <pes pesize="any" compset="_(CAM50|CAM60)%(CC|WC)">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>288</ntasks_atm>
-	  <ntasks_lnd>216</ntasks_lnd>
-	  <ntasks_rof>216</ntasks_rof>
-	  <ntasks_ice>63</ntasks_ice>
-	  <ntasks_ocn>18</ntasks_ocn>
-	  <ntasks_glc>288</ntasks_glc>
-	  <ntasks_wav>9</ntasks_wav>
-	  <ntasks_cpl>288</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>4</nthrds_atm>
-	  <nthrds_lnd>4</nthrds_lnd>
-	  <nthrds_rof>4</nthrds_rof>
-	  <nthrds_ice>4</nthrds_ice>
-	  <nthrds_ocn>4</nthrds_ocn>
-	  <nthrds_glc>4</nthrds_glc>
-	  <nthrds_wav>4</nthrds_wav>
-	  <nthrds_cpl>4</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>216</rootpe_ice>
-	  <rootpe_ocn>288</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>279</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
-      </pes>
-
     </mach>
   </grid>
   <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -100,10 +100,19 @@
       <option name="wallclock"> 00:30 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f09_g17" compset="BW1850" testmods="allactive/default">
+  <test name="SMS_Ld1" grid="f09_g17" compset="BW1850" testmods="allactive/default">
     <machines>
       <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="waccm"/>
+      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="SMS_Ld5" grid="f19_g17" compset="BWma1850" testmods="allactive/default">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="prebeta"/>
+      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>


### PR DESCRIPTION
. config_compsets.xml
   Add BWma1850 compset.

. config_pes.xml
   Corrected the compset match string for 1-degrees compsets on cheyenne
    -- line 1219.
   The compset match string at line 1252 looks suspect
   Removed the threaded PE layout for waccm/camchem on cheyenne

. testlist_allactive.xml
   Reduce the length of the BW1850 compset
   Add test for BWma1850 compset