### PR TITLE
Fixing ETEST compset by adding %SP to CLM in the compset long name

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -270,7 +270,7 @@
 
   <compset>
     <alias>ETEST</alias>
-    <lname>2000_CAM60_CLM50_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
+    <lname>2000_CAM60_CLM50%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
   </compset>
 
   <compset>


### PR DESCRIPTION
Fixing ETEST compset by adding %SP to CLM in the compset long name