### PR TITLE
Fixes to pe layouts on cheyenne for testing.

### DIFF
--- a/config_pes.xml
+++ b/config_pes.xml
@@ -78,7 +78,7 @@
   </grid>
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%gx1" >
     <mach name="cheyenne">
-      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+WW3.+">
+      <pes pesize="any" compset="CAM.+CLM.+CICE.+POP.+">
 	<comment>about 12ypd expected</comment>
         <ntasks>
           <ntasks_atm>288</ntasks_atm>

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -35,6 +35,13 @@
   <test name="NCK" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultio">
     <machines>
       <machine name="edison" compiler="intel" category="prebeta"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 02:00 </option>
+    </options>
+  </test>
+  <test name="NCK" grid="f19_g17" compset="B1850Ws" testmods="allactive/defaultiomi">
+    <machines>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
@@ -205,7 +212,7 @@
       <option name="comment">Needs to be B1850GWs rather than B1850G because WW3 currently does not support multi-instance</option>
     </options>
   </test>
-  <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
     <machines>
       <machine name="cheyenne" compiler="gnu" category="prealpha"/>
       <machine name="cheyenne" compiler="intel" category="prealpha"/>

--- a/testmods_dirs/allactive/defaultiomi/include_user_mods
+++ b/testmods_dirs/allactive/defaultiomi/include_user_mods
@@ -1,0 +1,1 @@
+../defaultio

--- a/testmods_dirs/allactive/defaultiomi/shell_commands
+++ b/testmods_dirs/allactive/defaultiomi/shell_commands
@@ -1,0 +1,1 @@
+./xmlchange NTASKS_OCN=-4


### PR DESCRIPTION
This changes some pe layouts that were causing some tests to fail on cheyenne.

Tested
  IRT_N3_Ld7.f19_g17.BHISTWs.cheyenne_intel.allactive-defaultio
  NCK.f19_g17.B1850Ws.cheyenne_intel.allactive-defaultiomi
  PET_PM.f19_g17.B1850.cheyenne_intel.allactive-defaultio 
