### PR TITLE
Fixing issue with defaultiomi and PET tests

### DIFF
--- a/testmods_dirs/allactive/defaultiomi/shell_commands
+++ b/testmods_dirs/allactive/defaultiomi/shell_commands
@@ -1,1 +1,1 @@
-./xmlchange NTASKS_OCN=-4
+./xmlchange NTASKS_OCN=144


### PR DESCRIPTION
Change NTASKS_OCN from number of nodes to number of tasks to work with changes in
the PET test.