### PR TITLE
Updated initial condition directory for f09 B1850

### DIFF
--- a/config_compsets.xml
+++ b/config_compsets.xml
@@ -313,8 +313,8 @@
 
     <entry id="RUN_REFCASE">
       <values match="first">
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD"     >b.e11.B1850C5CN.f09_g16.005_yr402_cesm2_v2</value>
-        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%null_m%gx1v7"      compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD"    >b.e11.B1850C5CN.f09_g16.005_yr402_cesm2_v2</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%ww3a_m%gx1v7"      compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD"     >b.e11.B1850C5CN.f09_g16.005_yr402_cesm2_v3</value>
+        <value grid="a%0.9x1.25_l%0.9x1.25_oi%gx1v7_r%r05_g%gland4_w%null_m%gx1v7"      compset="1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%NOEVOLVE_SWAV_BGC%BDRD"    >b.e11.B1850C5CN.f09_g16.005_yr402_cesm2_v3</value>
       </values>
     </entry>
 

--- a/testlist_allactive.xml
+++ b/testlist_allactive.xml
@@ -218,7 +218,7 @@
       <machine name="cheyenne" compiler="intel" category="prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 01:30 </option>
     </options>
   </test>
   <test name="PET" grid="ne30_g17" compset="B1850" testmods="allactive/defaultio">


### PR DESCRIPTION
Have f09 B1850 compsets point to updated hybrid startup directory and lengthen run-time for f19 test (b.e11.B1850C5CN.f09_g16.005_yr402_cesm2_v3). The directory has an updated CLM initial condition file so it can be used with newer CLM tags.